### PR TITLE
Update README.md for Arduino 1.8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,65 @@
-# Instructions for using the BSEC Arduino Library in Arduino 1.8.5
+# Instructions for using the BSEC Arduino Library in Arduino 1.8.8
 
-Until the Arduino IDE natively supports pre-compiled libraries, the following steps/hacks will need to be followed to integrate the BSEC library into your project.
+The following steps/hacks will need to be followed to integrate the BSEC library into your project.
 
 ## Installation and getting started
 
 ### 1. Install the latest Arduino IDE
 
-As of this publication, the latest Arduino IDE 1.8.5 can be downloaded from this [link](https://www.arduino.cc/download_handler.php)
+As of this publication, the latest Arduino IDE 1.8.8 can be downloaded from this [link](https://www.arduino.cc/download_handler.php)
 
 ### 2. Install the BSEC library
 
 Either download this library as a zip and import it into the Arduino IDE. Refer to [this](https://www.arduino.cc/en/Guide/Libraries) guide on how to import libraries.
 
-### 3. Replace the arduino-builder
-
-The `arduino-builder-PR219` now has the ability to select the appropriate pre-compiled library from the library folder.
-
-Replace the arduino-builder executable from the Arduino installation folder with the appropriate file based on your OS from this link [arduino-builder-219.zip](http://downloads.arduino.cc/PR/arduino-builder/arduino-builder-219.zip).
-
-### 4. Modify the platform.txt file
+### 3. Modify the platform.txt file
 
 If you have already used the previous example code remove the linker flag `-libalgobsec` in the platform.txt file.
 
-The arduino-builder passes the linker flags under `compiler.c.elf.extra_flags`. Most platform.txt files in the combine recipe place this previously unused variable in the start of the link recipe whereas it should be near the end along with the other pre-compiled libraries flags.
+The arduino-builder passes the linker flags under `{compiler.libraries.ldflags}`. Open you platform.txt and add this near the end of your recipe.c.combine.pattern.
 
 #### Examples
 
-##### ESP8266 community forum's ESP8266 core
+##### ESP8266 community forum's ESP8266 core v2.5.0-beta2
 
-Original line [91, 92](https://github.com/esp8266/Arduino/blob/42f824b2e4a1df8812306d40f2ea59a1323618c1/platform.txt#L91),
+Original line [103, 104](https://github.com/esp8266/Arduino/blob/0fd86a07f0b22aa43f24dc6158b6d8093b607765/platform.txt#L103),
 
 ```
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/arduino.ar" {compiler.c.elf.libs} -Wl,--end-group  "-L{build.path}"
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -Wl,-Map "-Wl,{build.path}/{build.project_name}.map" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} -Wl,--end-group  "-L{build.path}"
 ```
 
 should become
 
 ```
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags}  -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/arduino.ar" {compiler.c.elf.libs} {compiler.c.elf.extra_flags} -Wl,--end-group  "-L{build.path}"
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" -Wl,-Map "-Wl,{build.path}/{build.project_name}.map" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{archive_file_path}" {compiler.c.elf.libs} {compiler.libraries.ldflags} -Wl,--end-group  "-L{build.path}"
 ```
 
-##### Arduino's SAMD core
+##### Arduino's SAMD core v1.6.1
 
-Original line [95, 96](https://github.com/arduino/ArduinoCore-samd/blob/2facbf6177ef568b9f05cce204c1563bfa6362e4/platform.txt#L95),
+Original line [91, 92](https://github.com/arduino/ArduinoCore-samd/blob/ed40dd839eb6aa84b5d01ba16db57b687d99239d/platform.txt#L91),
 
 ```
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nano.specs --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--start-group {compiler.arm.cmsis.ldflags} -lm "{build.path}/{archive_file}" -Wl,--end-group
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nano.specs --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--start-group -lm "{build.path}/{archive_file}" -Wl,--end-group
 ```
 
 Should be,
 ```
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nano.specs --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--start-group {compiler.arm.cmsis.ldflags} -lm {compiler.c.elf.extra_flags} "{build.path}/{archive_file}" -Wl,--end-group
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nano.specs --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--start-group -lm {compiler.libraries.ldflags} "{build.path}/{archive_file}" -Wl,--end-group
 ```
 
-### 5. Only for the ESP8266 - modify the linker script
+### 4. Only for the ESP8266 - modify the linker script
 
-Due to the current size of the BSEC library, upon compilation, you will receive an error: ```section `.text' will not fit in region `iram1_0_seg'```. In order to solve this, you will need to modify the linker script and specifically define where the library should be placed in memory.
+Due to the current size of the BSEC library, upon compilation, you will receive an error: ```section `.text' will not fit in region `iram1_0_seg'```. In order to solve this, you will need to modify the source definition of the linker script and specifically define where the library should be placed in memory.
 
-You will need to modify the file `eagle.app.v6.common.ld` typically found in `{YourESP8266PPackageDirectory}\tools\sdk\ld`. 
+In previous versions of this manual it was stated that you need to edit `eagle.app.v6.common.ld` directly. Since this file is now generated at build time you will need to change the linker script file, `eagle.app.v6.common.ld.h` typically found in `{YourESP8266PPackageDirectory}\tools\sdk\ld`. 
 
-With reference to the linker script [here](https://github.com/esp8266/Arduino/blob/master/tools/sdk/ld/eagle.app.v6.common.ld),
+With reference to the linker script [here](https://github.com/esp8266/Arduino/blob/0fd86a07f0b22aa43f24dc6158b6d8093b607765/tools/sdk/ld/eagle.app.v6.common.ld.h#L138),
 
-After line [`117 *libwps.a:(.literal.* .text.*)`](https://github.com/esp8266/Arduino/blob/42f824b2e4a1df8812306d40f2ea59a1323618c1/tools/sdk/ld/eagle.app.v6.common.ld#L117),
-add `*libalgobsec.a:(.literal.* .text.*)`, which should look like,
+After line 138, add *libalgobsec.a:(.literal.* .text.*), which should look like,
 
 ```
     *libupgrade.a:(.literal.* .text.*)
@@ -74,17 +67,22 @@ add `*libalgobsec.a:(.literal.* .text.*)`, which should look like,
     *libwpa2.a:(.literal.* .text.*)
     *libwps.a:(.literal.* .text.*)
 	*libalgobsec.a:(.literal.* .text.*)
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.text.*)
-    _irom0_text_end = ABSOLUTE(.);
-    _flash_code_end = ABSOLUTE(.);
-  } >irom0_0_seg :irom0_0_phdr
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom0.text.* .irom.text .irom.text.*)
+
+    /* __FUNCTION__ locals */
+    *(.rodata._ZZ*__FUNCTION__)
 ```
 
-### 6. Copy the binaries
+### 5. Copy the binaries
 
-If you have already used the previous example code remove the `libalgobsec.a` file from the core directory or any other location you might have copied it to and instead, copy the binaries from the zip file available via our [website](https://www.bosch-sensortec.com/en/bst/products/all_products/bsec), to where the Arduino library is installed on your system. For Windows, this is typically under `Documents/Arduino/libraries/BSEC-Arduino-library-master`. The name of the library may differ depending how you installed it.
+If you have already used the previous example code remove the `libalgobsec.a` file from the core directory or any other location you might have copied it to and instead, copy the binaries from the zip file available via our [website](https://www.bosch-sensortec.com/en/bst/products/all_products/bsec), to where the Arduino library is installed on your system. 
+For Windows, there are three typical locations where the library might be imported.
+- `Documents/Arduino/libraries/bsec`
+- `C:\Program Files (x86)\Arduino\libraries\bsec`
+- `<Sketchbook location>\libraries\bsec`
+The library name might differ depending on how you installed it, e.g. bsec, BSEC-Arduino-library-master or similar. Find your <Sketchbook location> by opening Arduino IDE and going to ```File>Preferences```. If the library is imported correctly, you will see multiple subfolders containing text files.
 
-| From the .zip (algo/bin/Normal_version/) | To (Documents/Arduino/libraries/BSEC-Arduino-library-master/src/) |
+| From the .zip (algo/bin/Normal_version/) | To (<bsec-lib>/src/) |
 |------|----|
 | avr/AVR8_megaAVR | atmega2560 |
 | gcc/Cortex_M0+ | cortex-m0plus |
@@ -94,15 +92,15 @@ If you have already used the previous example code remove the `libalgobsec.a` fi
 | esp32 |  esp32 |
 | esp8266 |  esp8266 |
 
-### 7. Verify and upload the example code
+### 6. Verify and upload the example code
 
-Start or restart the Arduino IDE. Open the example code found under ```File>Examples>Bsec software library>Basic```.
+Start or restart the Arduino IDE. Open the example code found under ```File>Examples>BSEC Software Library>basic```.
 
 Select your board and COM port. Upload the example. Open the Serial monitor. You should see an output on the terminal.
 
 Note that not all supported cores have been tested. In such cases, the examples can be found under ```File>Examples>INCOMPATIBLE>Bsec software library>Basic```
 
-### 8. Tested board list
+### 7. Tested board list
 
 The current list of tested micro-controllers include,
 


### PR DESCRIPTION
Updated the Readme to support the changes in Arduino 1.8.8 and ESP8266 core for Arduino 2.5.0-beta2.
SAMD core instructions are untested.