### PR TITLE
Add PlatformIO library manager manifest

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -1,0 +1,7 @@
+Import('env')
+from os.path import join, realpath
+
+env.Append(
+    LIBPATH=[realpath(join('src', env.get('BOARD_MCU')))],
+    LIBS=['algobsec']
+)

--- a/library.json
+++ b/library.json
@@ -1,0 +1,47 @@
+{
+  "name": "BSEC Software Library",
+  "description": "Bosch Sensortec Environmental Cluster (BSEC) Software library for use with the BME680 has been conceptualized to provide higher-level signal processing and fusion for the BME680. The library receives compensated sensor values from the sensor API. It processes the BME680 signals to provide the requested sensor outputs.",
+  "homepage": "https://www.bosch-sensortec.com/software-tools/software/bsec/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BoschSensortec/BSEC-Arduino-library"
+  },
+  "version": "1.5.1474",
+  "authors": {
+    "name": "Bosch Sensortec",
+    "email": "contact@bosch-sensortec.com"
+  },
+  "frameworks": "arduino",
+  "platforms": "*",
+  "build": {
+    "includeDir": "src/inc",
+    "extraScript": "extra_script.py"
+  },
+  "examples": [
+    {
+      "name": "Basic usage",
+      "base": "examples/basic",
+      "files": ["basic.ino"]
+    },
+    {
+      "name": "Basic usage with config state saves",
+      "base": "examples/basic_config_state",
+      "files": ["basic_config_state.ino"]
+    },
+    {
+      "name": "Basic usage with config state saves and multiple sensors",
+      "base": "examples/basic_config_state_multi",
+      "files": ["basic_config_state_multi.ino"]
+    },
+    {
+      "name": "Basic usage with config state saves and triggered ULP plus measurements",
+      "base": "examples/basic_config_state_ulp_plus",
+      "files": ["basic_config_state_ulp_plus.ino"]
+    },
+    {
+      "name": "ESP32 deep sleep",
+      "base": "examples/esp32DeepSleep",
+      "files": ["esp32DeepSleep.ino"]
+    }
+  ]
+}


### PR DESCRIPTION
I have been using the libary for a while now in a Platform IO project which required me to add extra build flags to link the library. This has been working well, but I have recently migrated my project to run under ESPHome where I have less elegant control over the necessary build flags which prompted me to look into a better solution.

This PR adds a [Platform IO library.json](https://docs.platformio.org/en/latest/librarymanager/config.html) which references an extra build script to set the necessary build flags for library linking without manual intervention or amendments.

Whilst researching this solution it seems that I am far from the first to be using the library in this ecosystem so hopefully this manifest can be incorporated into the next release and be of benefit to other users.