### PR TITLE
Update bsec.cpp

### DIFF
--- a/src/bsec.cpp
+++ b/src/bsec.cpp
@@ -199,7 +199,7 @@ bool Bsec::run(int64_t timeMilliseconds)
 
     if (callTimeMs >= nextCall)
     {
-        bsec_init();
+        // bsec_init();
 
         if (validBsecState)
         {
@@ -388,7 +388,7 @@ bool Bsec::readProcessData(int64_t currTimeNs, bsec_bme_settings_t bme680Setting
             return false;
         }
 
-        zeroOutputs();
+        // zeroOutputs();
 
         if (nOutputs > 0)
         {


### PR DESCRIPTION
The ULP_LP examples just doesn't work.
Minhwan found that omitting bsec_init in run() made the example work better.
I found that omitting zeroOutputs in processOutput() made the VOC parts not going to zero.
Having no insight in the BSEC library source code I don't know if this is the correct solution but ULP_LP is not working as is...