### PR TITLE
Fix regression in #include directive paths

### DIFF
--- a/src/bsec.h
+++ b/src/bsec.h
@@ -43,9 +43,9 @@
 #include "Arduino.h"
 #include "Wire.h"
 #include "SPI.h"
-#include "bsec_datatypes.h"
-#include "bsec_interface.h"
-#include "bme68x.h"
+#include "inc/bsec_datatypes.h"
+#include "inc/bsec_interface.h"
+#include "bme68x/bme68x.h"
 
 #define BME68X_ERROR            INT8_C(-1)
 #define BME68X_WARNING          INT8_C(1)


### PR DESCRIPTION
These `#include` directives were modified to expect the target files in the same folder as the containing file (https://github.com/boschsensortec/BSEC-Arduino-library/commit/f772ae1125f56d4495406e848dedd9642af3bb14), but those files are not in that folder. This caused compilation of any sketch using the library to fail:

```cpp
#include <bsec.h>
void setup() {}
void loop() {}
```


```text
c:\Users\per\Documents\Arduino\libraries\BSEC_Software_Library\src/bsec.h:46:10: fatal error: bsec_datatypes.h: No such file or directory #include "bsec_datatypes.h"
^~~~~~~~~~~~~~~~~~
```

The target files are in the `inc` subfolder, so that relative path must be specified in the `#include` directive as before.